### PR TITLE
Fix for initial Chef run

### DIFF
--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -101,7 +101,11 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
       brick_count = 0
       peers = volume_values.attribute?('peer_names') ? volume_values['peer_names'] : volume_values['peers']
       peers.each do |peer|
-        chef_node = Chef::Node.find_or_create(peer)
+        if peer == node['hostname'] || node['fqdn']
+          chef_node = node
+        else 
+          chef_node = Chef::Node.find_or_create(peer)
+        end
         if chef_node['gluster']['server'].attribute?('bricks')
           peer_bricks = chef_node['gluster']['server']['bricks'].select { |brick| brick.include? volume_name }
           volume_bricks[peer] = peer_bricks


### PR DESCRIPTION
On the first chef run (useful for me as I deploy entire stacks), previously the recipe would try to look up itself via the chef server. Because the chef run had not completed yet, this would fail and would try and make the volume with only the other nodes already registered. This little fix uses the already loaded node object instead.