### PR TITLE
Checks if peers are in the right state before trying to create the volume

### DIFF
--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -143,6 +143,14 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
         end
       end
 
+      #Ensure that all peers are actually in the correct state before we try to make the volume
+      peers.each do |peer|
+        bash "reprobe-peer" do
+          command "gluster peer detach #{peer}; gluster peer probe #{peer}"
+          only_if %Q{"execute "gluster peer status | grep -A 2 #{peer} | tail -1 | grep 'Peer in Cluster (Connected)'"}
+        end
+      end
+        
       execute "gluster volume create #{volume_name} #{options}" do
         action :run
       end


### PR DESCRIPTION
Sometimes the peer probe will not go well and then the initial create will fail, this runs gluster peer status and ensures the peers are in the correct state (In cluster/connected). If not, it'll run a peer detach and a peer probe. Not sure if it should do this or just exit to be honest, but it definitely shouldn't try to do a volume create without checking first.