### PR TITLE
glusterfsd must be started for shutdown cleanup

### DIFF
--- a/recipes/server_install.rb
+++ b/recipes/server_install.rb
@@ -36,3 +36,13 @@ service node['gluster']['server']['servicename'] do
     action [:disable, :stop]
   end
 end
+
+# Make sure the brick service is started
+service 'glusterfsd' do
+  if node['gluster']['server']['enable']
+    action [:enable, :start]
+  else
+    action [:disable, :stop]
+  end
+  only_if { node['platform_family'] == 'rhel' && node['platform_version'].to_f >= 7.0 }
+end


### PR DESCRIPTION
https://lists.gnu.org/archive/html/gluster-devel/2013-03/msg00135.html
Only needed for RHEL 7+ since it is on systemd