### PR TITLE
allow mount options to be set on gluster mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ end
 
 - `mount_point` - The mount point on the local server to mount the glusterfs volume on. Created if non-existing. Required.
 
+- `mount_options` - Additional mount options added to the default options set `defaults,_netdev`. Optional.
+
 - `owner` - Owner of the underlying mount point directory. Defaults to `nil`. Optional.
 
 - `group` - Group of the underlying mount point directory. Defaults to `nil`. Optional.

--- a/providers/mount.rb
+++ b/providers/mount.rb
@@ -70,17 +70,23 @@ def enable_volume
 end
 
 def mount_options
-  # Define a backup server for this volume, if available
-  options = 'defaults,_netdev'
-  unless new_resource.backup_server.nil?
-    case
-    when new_resource.backup_server.class == String
-      options += ',backupvolfile-server=' + new_resource.backup_server
-    when new_resource.backup_server.class == Array
-      options += ',backupvolfile-server=' + new_resource.backup_server.join(',backupvolfile-server=')
-    end
+  "#{basic_mount_options}#{mount_options_for_backup_server}"
+end
+
+def basic_mount_options
+  [
+    'defaults,_netdev',
+    new_resource.mount_options || []
+  ].flatten(1).join(',')
+end
+
+def mount_options_for_backup_server
+  case
+  when new_resource.backup_server.class == String
+    ',backupvolfile-server=' + new_resource.backup_server
+  when new_resource.backup_server.class == Array
+    ',backupvolfile-server=' + new_resource.backup_server.join(',backupvolfile-server=')
   end
-  options
 end
 
 def mount_volume

--- a/resources/mount.rb
+++ b/resources/mount.rb
@@ -28,3 +28,4 @@ attribute :group, kind_of: String, default: nil
 attribute :mode, kind_of: String, default: nil
 attribute :backup_server, kind_of: [String, Array], default: nil
 attribute :mount_point, kind_of: String, default: nil, required: true
+attribute :mount_options, kind_of: [String, Array], default: nil


### PR DESCRIPTION
I ran into the case where I wanted to mount a glusterfs volume read only, which led me to implement a more generic way to set options on the mount point.