### PR TITLE
Fix brick_in_volume for long hostnames

### DIFF
--- a/libraries/gluster.rb
+++ b/libraries/gluster.rb
@@ -9,7 +9,7 @@ def node_peer?(node)
 end
 
 def peer_in_volume?(peer, volume)
-  cmd = shell_out("gluster volume status #{volume} | awk '{print $2}' | awk -F : '{print $1}' | grep #{peer} | uniq")
+  cmd = shell_out("gluster volume info #{volume} | awk '{print $2}' | awk -F : '{print $1}' | grep #{peer} | uniq")
   # cmd.stdout has a \n at the end of it
   if cmd.stdout.chomp == node
     return true

--- a/libraries/gluster.rb
+++ b/libraries/gluster.rb
@@ -19,7 +19,7 @@ def peer_in_volume?(peer, volume)
 end
 
 def brick_in_volume?(peer, brick, volume)
-  cmd = shell_out("gluster volume status #{volume} | awk '{print $2}' | grep #{peer}:#{brick}")
+  cmd = shell_out("gluster volume info #{volume} | awk '{print $2}' | grep #{peer}:#{brick}")
   # cmd.stdout has a \n at the end of it
   if cmd.stdout.chomp == "#{peer}:#{brick}"
     return true


### PR DESCRIPTION
`gluster volume status` wraps the `peer:brick` to multiple lines if it is longer than the table column width. This causes the `grep` to miss it. It works correctly using `gluster volume info` instead as that does not wrap it.

```
root@mylongehostname-gluster1 [ ~ ] (15:49:46 - Wed Oct 28)
> gluster volume status gv0
Status of volume: gv0
Gluster process                             TCP Port  RDMA Port  Online  Pid
------------------------------------------------------------------------------
Brick mylongehostname-gluster2:/gluster/xvd
b1/gv0                                      49154     0          Y       19122
Brick mylongehostname-gluster1:/gluster/xvd
b1/gv0                                      49154     0          Y       13050
NFS Server on localhost                     N/A       N/A        N       N/A
Self-heal Daemon on localhost               N/A       N/A        Y       13077
NFS Server on mylongehostname-gluster2      N/A       N/A        N       N/A
Self-heal Daemon on mylongehostname-gluster
1                                           N/A       N/A        Y       19149

Task Status of Volume gv0
------------------------------------------------------------------------------
There are no active volume tasks

root@mylongehostname-gluster1 [ ~ ] (16:00:48 - Wed Oct 28)
> gluster volume status gv0 | awk '{print $2}' | grep mylongehostname-gluster1:/gluster/xvdb1/gv0
```


```
root@mylongehostname-gluster1 [ ~ ] (15:50:28 - Wed Oct 28)
> gluster volume info gv0

Volume Name: gv0
Type: Replicate
Volume ID: 5f68e934-d2ff-4b6f-836c-5c5d077ec8ce
Status: Started
Number of Bricks: 1 x 2 = 2
Transport-type: tcp
Bricks:
Brick1: mylongehostname-gluster2:/gluster/xvdb1/gv0
Brick2: mylongehostname-gluster1:/gluster/xvdb1/gv0
Options Reconfigured:
performance.readdir-ahead: on

root@mylongehostname-gluster1 [ ~ ] (16:00:59 - Wed Oct 28)
> gluster volume info gv0 | awk '{print $2}' | grep mylongehostname-gluster1/gluster/xvdb1/gv0
mylongehostname-gluster1:/gluster/xvdb1/gv0
```