### PR TITLE
Correct the usage of the peer_names attribute

### DIFF
--- a/recipes/server_extend.rb
+++ b/recipes/server_extend.rb
@@ -24,9 +24,14 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
     peer_bricks = chef_node['gluster']['server']['volumes'][volume_name]['bricks'].select { |brick| brick.include? volume_name }
     brick_count += (peer_bricks.count || 0)
     peer_bricks.each do |brick|
-      Chef::Log.info("Checking #{peer}:#{brick}")
-      unless brick_in_volume?(peer, brick, volume_name)
-        node.default['gluster']['server']['volumes'][volume_name]['bricks_waiting_to_join'] << " #{peer}:#{brick}"
+      peer_name = if volume_values.attribute?('peer_names')
+                    volume_values['peers'][peers.index(peer)]
+                  else
+                    peer
+                  end
+      Chef::Log.info("Checking #{peer_name}:#{brick}")
+      unless brick_in_volume?(peer_name, brick, volume_name)
+        node.default['gluster']['server']['volumes'][volume_name]['bricks_waiting_to_join'] << " #{peer_name}:#{brick}"
       end
     end
   end

--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -78,8 +78,7 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
       # Create a hash of peers and their bricks
       volume_bricks = {}
       brick_count = 0
-      peers = volume_values.attribute?('peer_names') ? volume_values['peer_names'] : volume_values['peers']
-      peers.each do |peer|
+      volume_values['peers'].each do |peer|
         # As every server will be running the same code, we know what the brick paths will be on every node
         if node['gluster']['server']['volumes'][volume_name].attribute?('bricks')
           peer_bricks = node['gluster']['server']['volumes'][volume_name]['bricks']


### PR DESCRIPTION
@Seth-Karlo this look right to you?
This fixes the usage of `peer_names` so that it is only used when loading nodes from chef
(It assumes that `peer_names` and `peer` are sorted and are a 1:1 match)