### PR TITLE
Allow host check to match when hostname is listed under 'Other names'

### DIFF
--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -66,7 +66,7 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
         retry_delay node['gluster']['server']['peer_retry_delay']
       end
       # Wait here until the peer reaches connected status (needed for volume create later)
-      execute "gluster peer status | grep -A 2 #{peer} | tail -1 | grep 'Peer in Cluster (Connected)'" do
+      execute "gluster peer status | sed -e '/Other names:/d' | grep -A 2 -B 1 #{peer} | grep 'Peer in Cluster (Connected)'" do
         action :run
         retries node['gluster']['server']['peer_wait_retries']
         retry_delay node['gluster']['server']['peer_wait_retry_delay']


### PR DESCRIPTION
I ran into issues where the `gluster peer probe` command was returning the peer's IP address as the hostname and the actual hostname under "Other names".

```
> sudo gluster peer status
Number of Peers: 1

Hostname: 192.168.1.1
Uuid: d1111111-cb43-1234-5677-6de84e12f73
State: Peer in Cluster (Connected)
Other names:
gluster2.example.com
```

I modified the command to filter out the 'Other names' line so that the 'Connected' line would always be above it.  Then we have grep return two lines after a match and one line before. This was to prevent a situation where the command didn't return nodes that have 'other names' and a connected message for a prior node would appear two lines above the node being probed. 

I'd be happy to try out other approaches if there might be a cleaner method.