### PR TITLE
Fix problems with volume_extend recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - **[PR #58](https://github.com/shortdudey123/chef-gluster/pull/58)** - Fix case statement syntax
+- **[PR #59](https://github.com/shortdudey123/chef-gluster/pull/59)** - Fix problems with volume_extend recipe
 - **[PR #61](https://github.com/shortdudey123/chef-gluster/pull/61)** - Update disk controller logic for Vagrant template
 
 ## v5.0.1 (2016-03-12)

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -34,9 +34,9 @@ default['gluster']['server']['enable'] = true
 # Package dependencies
 case node['platform']
 when 'ubuntu'
-  default['gluster']['server']['dependencies'] = ['xfsprogs']
+  default['gluster']['server']['dependencies'] = %w(xfsprogs lvm2)
 when 'redhat', 'centos'
-  default['gluster']['server']['dependencies'] = ['xfsprogs']
+  default['gluster']['server']['dependencies'] = %w(xfsprogs lvm2)
 end
 
 # Default path to use for mounting bricks

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -22,4 +22,9 @@ include_recipe 'gluster::server_install'
 include_recipe 'lvm'
 include_recipe 'gluster::server_setup'
 include_recipe 'gluster::server_extend'
-include_recipe 'gluster::volume_extend'
+include_recipe 'gluster::volume_extend' if begin
+                                             Gem::Specification.find_by_name('di-ruby-lvm')
+                                           rescue Gem::LoadError
+                                             Chef::Log.info('not including gluster::volume_extend since di-ruby-lvm was not found')
+                                             return false
+                                           end

--- a/recipes/server_install.rb
+++ b/recipes/server_install.rb
@@ -22,7 +22,9 @@ include_recipe 'gluster::repository' unless node['gluster']['repo'] == 'private'
 
 # Install dependencies
 node['gluster']['server']['dependencies'].each do |d|
-  package d
+  package d do
+    action :nothing
+  end.run_action :install
 end
 
 # Install the server package


### PR DESCRIPTION
Hi @shortdudey123,

the behaviour of the LVM cookbook has changed in version ```> 2.0```.

To use a newer version of the LVM cookbook someone has to rewrite the ```volume_extend.rb``` recipe. :angel: 

Best,
Dennis