### PR TITLE
Update disk controller logic for Vagrant template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - **[PR #58](https://github.com/shortdudey123/chef-gluster/pull/58)** - Fix case statement syntax
+- **[PR #61](https://github.com/shortdudey123/chef-gluster/pull/61)** - Update disk controller logic for Vagrant template
 
 ## v5.0.1 (2016-03-12)
 - **[PR #52](https://github.com/shortdudey123/chef-gluster/pull/52)** - Correct the usage of the peer_names attribute

--- a/test/integration/Vagrantfile.erb
+++ b/test/integration/Vagrantfile.erb
@@ -1,8 +1,8 @@
 Vagrant.configure("2") do |c|
   c.vm.box = "<%= config[:box] %>"
   c.vm.box_url = "<%= config[:box_url] %>"
-  
-<% if config[:box] == "opscode-centos-7.1" || config[:box] == "opscode-ubuntu-14.04"
+
+<% if ['opscode-centos-7.1', 'opscode-ubuntu-14.04', 'bento/centos-7.1', 'bento/ubuntu-14.04'].include?(config[:box])
      disk_controller = "SATA"
    else
      disk_controller = "IDE"


### PR DESCRIPTION
Newers versions of test-kitchen are using bento/* instead of opscode-* for the vagrant box names.  This means that both the old and new name convetion need to be in the vagrant template that test-kitchen uses