### PR TITLE
Update yum_repository resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **[PR #66](https://github.com/shortdudey123/chef-gluster/pull/66)** - Update test-kitchen OS's
 - **[PR #67](https://github.com/shortdudey123/chef-gluster/pull/67)** - Fix serverspec verification
 - **[PR #68](https://github.com/shortdudey123/chef-gluster/pull/68)** - Add kitchen testing for gluster::client recipe
+- **[PR #69](https://github.com/shortdudey123/chef-gluster/pull/69)** - Update yum_repository resource
 
 ## v5.0.1 (2016-03-12)
 - **[PR #52](https://github.com/shortdudey123/chef-gluster/pull/52)** - Correct the usage of the peer_names attribute

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -55,7 +55,7 @@ when 'redhat', 'centos'
              end
 
   yum_repository 'glusterfs' do
-    url repo_url
+    baseurl repo_url
     gpgcheck false
     action :create
   end


### PR DESCRIPTION
`url` param for `yum_repository` was removed when the resource was copied from the yum cookbook into chef itself
See https://github.com/chef/chef/issues/5317