### PR TITLE
Bump Gluster version to 3.8

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,8 +6,8 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-12.04
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
   - name: centos-6.8
   - name: centos-7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **[PR #72](https://github.com/shortdudey123/chef-gluster/pull/72)** - Fix backup-volfile-server(s) in mount provider
 - **[PR #73](https://github.com/shortdudey123/chef-gluster/pull/73)** - Bump Travis ruby version to 2.3.1
+- **[PR #74](https://github.com/shortdudey123/chef-gluster/pull/74)** - Bump Gluster version to 3.8
 - **[PR #75](https://github.com/shortdudey123/chef-gluster/pull/75)** - Disable Metrics/BlockLength cop
 
 ## v5.0.2 (2016-09-14)

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ There is a kitchen file provided to allow testing of the various versions. Examp
 
 (Depending on your shell, you may or may not need the \ in the RegEx)
 
-To test a replicated volume on Ubuntu 12.04:
-kitchen converge replicated\[12]-ubuntu-1204
-kitchen verify replicated2-ubuntu-1204
+To test a replicated volume on Ubuntu 16.04:
+kitchen converge replicated\[12]-ubuntu-1604
+kitchen verify replicated2-ubuntu-1604
 
 To test a distributed-replicated volume on CentOS 7.2:
 kitchen converge distributed-repl\[1234]-centos-72

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,5 @@
 # limitations under the License.
 #
 
-default['gluster']['version'] = '3.6'
+default['gluster']['version'] = '3.8'
 default['gluster']['repo'] = 'public'


### PR DESCRIPTION
Gluster 3.6 was EOL'd last week with the release of 3.9