### PR TITLE
Allow customize brick directory by attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # gluster cookbook CHANGELOG
 
 ## Unreleased
+- **[PR #78](https://github.com/shortdudey123/chef-gluster/pull/78)** - Allow customize brick directory by attribute
 - **[PR #77](https://github.com/shortdudey123/chef-gluster/pull/77)** - Allow use gluster recipe on already existed filesystem
 
 ## v5.1.0 (2016-12-02)

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -46,7 +46,11 @@ default['gluster']['server']['volumes'] = {}
 # Set by the cookbook once bricks are configured and ready to use
 default['gluster']['server']['bricks'] = []
 
+# List of disk managed by lvm
 default['gluster']['server']['disks'] = []
+
+# default brick directory name
+default['gluster']['server']['brick_dir'] = 'brick'
 
 # Retry delays for attempting peering
 default['gluster']['server']['peer_retries'] = 0

--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -59,7 +59,7 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
       end
     end
 
-    bricks << "#{node['gluster']['server']['brick_mount_path']}/#{volume_name}/brick"
+    bricks << "#{node['gluster']['server']['brick_mount_path']}/#{volume_name}/#{node['gluster']['server']['brick_dir']}"
     # Save the array of bricks to the node's attributes
     node.normal['gluster']['server']['volumes'][volume_name]['bricks'] = bricks
   else


### PR DESCRIPTION
Small patch to allow change brick dir name with default "brick" - as in previous version.