### PR TITLE
Fix gluster volume create force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # gluster cookbook CHANGELOG
 
 ## Unreleased
-- **[PR #78](https://github.com/shortdudey123/chef-gluster/pull/78)** - Allow customize brick directory by attribute
 - **[PR #77](https://github.com/shortdudey123/chef-gluster/pull/77)** - Allow use gluster recipe on already existed filesystem
+- **[PR #78](https://github.com/shortdudey123/chef-gluster/pull/78)** - Allow customize brick directory by attribute
+- **[PR #79](https://github.com/shortdudey123/chef-gluster/pull/79)** - Fix gluster volume create force
 
 ## v5.1.0 (2016-12-02)
 - **[PR #72](https://github.com/shortdudey123/chef-gluster/pull/72)** - Fix backup-volfile-server(s) in mount provider


### PR DESCRIPTION
Since we are allowing gluster volumes to be created on the root parition when lvm management is not being used, gluster volume create must have the force option added.  Since the determination of the volume mount location happens in the compile phase, but the directory creation happens in the converge phase, the determination will always be false since the directory does not exist yet.

This moves the check and force directive into a lazy evaluation block so solve the problem.

```
* execute[gluster volume create gv0 replica 2 gluster2:/data/gv0/brick gluster1:/data/gv0/brick] action run

  ================================================================================
  Error executing action `run` on resource 'execute[gluster volume create gv0 replica 2 gluster2:/data/gv0/brick gluster1:/data/gv0/brick]'
  ================================================================================

  Mixlib::ShellOut::ShellCommandFailed
  ------------------------------------
  Expected process to exit with [0], but received '1'
  ---- Begin output of gluster volume create gv0 replica 2 gluster2:/data/gv0/brick gluster1:/data/gv0/brick ----
  STDOUT:
  STDERR: volume create: gv0: failed: The brick gluster2:/data/gv0/brick is being created in the root partition. It is recommended that you don't use the system's root partition for storage backend. Or use 'force' at the end of the command if you want to override this behavior.
  ---- End output of gluster volume create gv0 replica 2 gluster2:/data/gv0/brick gluster1:/data/gv0/brick ----
  Ran gluster volume create gv0 replica 2 gluster2:/data/gv0/brick gluster1:/data/gv0/brick returned 1

  Resource Declaration:
  ---------------------
  # In /tmp/kitchen/cache/cookbooks/gluster/recipes/server_setup.rb

  166:         execute "gluster volume create #{volume_name} #{options}" do
  167:           action :run
  168:           not_if options.empty?
  169:         end
  170:       end

  Compiled Resource:
  ------------------
  # Declared in /tmp/kitchen/cache/cookbooks/gluster/recipes/server_setup.rb:166:in `block in from_file'

  execute("gluster volume create gv0 replica 2 gluster2:/data/gv0/brick gluster1:/data/gv0/brick") do
    action [:run]
    retries 0
    retry_delay 2
    default_guard_interpreter :execute
    command "gluster volume create gv0 replica 2 gluster2:/data/gv0/brick gluster1:/data/gv0/brick"
    backup 5
    returns 0
    declared_type :execute
    cookbook_name "gluster"
    recipe_name "server_setup"
  end

  Platform:
  ---------
  x86_64-linux
```