### PR TITLE
Use GPG keys on yum repositories and Support 3.9 on yum via the buildlogs.centos.org testing repository

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -49,8 +49,15 @@ when 'ubuntu'
 when 'redhat', 'centos'
   # CentOS 6 and 7 have Gluster in the Storage SIG instead of a gluster hosted repo
   if node['platform_version'].to_i > 5
-    repo_url = "http://mirror.centos.org/centos/$releasever/storage/$basearch/gluster-#{node['gluster']['version']}/"
-    gpg_url = 'https://raw.githubusercontent.com/CentOS-Storage-SIG/centos-release-storage-common/master/RPM-GPG-KEY-CentOS-SIG-Storage'
+    if Chef::VersionConstraint.new('>= 3.9').include?(node['gluster']['version'])
+      subdomain = 'buildlogs'
+      gpg_url = nil
+    else
+      subdomain = 'mirror'
+      gpg_url = 'https://raw.githubusercontent.com/CentOS-Storage-SIG/centos-release-storage-common/master/RPM-GPG-KEY-CentOS-SIG-Storage'
+    end
+
+    repo_url = "http://#{subdomain}.centos.org/centos/$releasever/storage/$basearch/gluster-#{node['gluster']['version']}/"
   else
     url = "https://download.gluster.org/pub/gluster/glusterfs/#{node['gluster']['version']}/LATEST/EPEL.repo"
     repo_url = "#{url}/epel-$releasever/$basearch/"
@@ -60,6 +67,7 @@ when 'redhat', 'centos'
   yum_repository 'glusterfs' do
     baseurl repo_url
     gpgkey gpg_url
+    gpgcheck !gpg_url.nil?
     action :create
   end
 end

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -48,15 +48,18 @@ when 'ubuntu'
   end
 when 'redhat', 'centos'
   # CentOS 6 and 7 have Gluster in the Storage SIG instead of a gluster hosted repo
-  repo_url = if node['platform_version'].to_i > 5
-               "http://mirror.centos.org/centos/$releasever/storage/$basearch/gluster-#{node['gluster']['version']}/"
-             else
-               "https://download.gluster.org/pub/gluster/glusterfs/#{node['gluster']['version']}/LATEST/EPEL.repo/epel-$releasever/$basearch/"
-             end
+  if node['platform_version'].to_i > 5
+    repo_url = "http://mirror.centos.org/centos/$releasever/storage/$basearch/gluster-#{node['gluster']['version']}/"
+    gpg_url = 'https://raw.githubusercontent.com/CentOS-Storage-SIG/centos-release-storage-common/master/RPM-GPG-KEY-CentOS-SIG-Storage'
+  else
+    url = "https://download.gluster.org/pub/gluster/glusterfs/#{node['gluster']['version']}/LATEST/EPEL.repo"
+    repo_url = "#{url}/epel-$releasever/$basearch/"
+    gpg_url = "#{url}/dsa.pub"
+  end
 
   yum_repository 'glusterfs' do
     baseurl repo_url
-    gpgcheck false
+    gpgkey gpg_url
     action :create
   end
 end


### PR DESCRIPTION
I found that Kitchen had some trouble with the LVM gem stuff but it at least got as far as installing the packages so I was able to test these changes.

I'm only interested in Geo Replication, which this cookbook doesn't cover, but it's still useful for installing the packages. This feature has improved significantly in 3.9, hence why I've added support for that.