### PR TITLE
Depend on compat_resource instead of apt and yum cookbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # gluster cookbook CHANGELOG
 
 ## Unreleased
+- **[PR #92](https://github.com/shortdudey123/chef-gluster/pull/92)** - Depend on compat_resource instead of apt and yum cookbooks
 
 ## v5.3.0 (2017-01-03)
 - **[PR #82](https://github.com/shortdudey123/chef-gluster/pull/82)** - Add license and fix readme

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,7 @@ license          'Apache 2.0'
 description      'Installs and configures Gluster servers and clients'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '5.3.0'
-depends          'apt', '>= 2.0'
-depends          'yum', '>= 3.0'
+depends          'compat_resource', '>= 12.14.6'
 depends          'lvm', '>= 1.5.1'
 
 source_url 'https://github.com/shortdudey123/chef-gluster' if respond_to?(:source_url)

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -20,7 +20,7 @@
 
 case node['platform']
 when 'debian'
-  include_recipe 'apt::default'
+  package 'apt-transport-https'
 
   apt_repository "glusterfs-#{node['gluster']['version']}" do
     uri "https://download.gluster.org/pub/gluster/glusterfs/#{node['gluster']['version']}/LATEST/Debian/#{node['lsb']['codename']}/apt"
@@ -33,8 +33,6 @@ when 'debian'
     end
   end
 when 'ubuntu'
-  include_recipe 'apt::default'
-
   apt_repository "glusterfs-#{node['gluster']['version']}" do
     uri "http://ppa.launchpad.net/gluster/glusterfs-#{node['gluster']['version']}/ubuntu"
     distribution node['lsb']['codename']


### PR DESCRIPTION
apt_repository and yum_repository are built into Chef now. Debian
needs apt-transport-https explicitly installed until chef/chef#5310 is
resolved.