### PR TITLE
Add gluster_volume custom resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,51 @@ Other attributes include:
 
 ## Custom Resources
 
+### gluster_volume
+
+Use this resource to start, stop, or delete volumes:
+
+```ruby
+gluster_volume 'volume_name' do
+  action :start
+end
+```
+
+```ruby
+gluster_volume 'volume_name' do
+  action :stop
+end
+```
+
+```ruby
+gluster_volume 'volume_name' do
+  action :delete
+end
+```
+
+It is also useful for checking existence in `only_if` blocks:
+
+```ruby
+volume = gluster_volume 'volume_name' do
+  action :nothing
+end
+
+some_resource 'foo' do
+  only_if { volume.current_value }
+end
+```
+
+```ruby
+gluster_volume 'volume_name' do
+  action :start
+  only_if { current_value }
+end
+```
+
+#### Parameters
+
+- `volume_name` - The volume name. Defaults to the resource name.
+
 ### gluster_mount
 
 Use this resource to mount volumes on clients:

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -23,6 +23,18 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:gluster_mountbroker_user, :remove, resource_name)
   end
 
+  def delete_gluster_volume(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:gluster_volume, :delete, resource_name)
+  end
+
+  def start_gluster_volume(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:gluster_volume, :start, resource_name)
+  end
+
+  def stop_gluster_volume(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:gluster_volume, :stop, resource_name)
+  end
+
   def set_gluster_volume_option(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:gluster_volume_option, :set, resource_name)
   end

--- a/resources/volume.rb
+++ b/resources/volume.rb
@@ -1,0 +1,59 @@
+#
+# Cookbook Name:: gluster
+# Resource:: volume
+#
+# Copyright 2017, Yakara Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property :volume_name, String,
+         name_property: true
+
+property :started, [TrueClass, FalseClass]
+
+default_action :nothing
+
+load_current_value do
+  cmd = shell_out('gluster', 'volume', 'info', volume_name)
+
+  if cmd.error?
+    current_value_does_not_exist!
+  else
+    started !(cmd.stdout =~ /^Status: Started$/).nil?
+  end
+end
+
+action :start do
+  unless current_resource.started # ~FC023
+    converge_by ["start volume #{volume_name}"] do
+      shell_out!('gluster', 'volume', 'start', volume_name)
+    end
+  end
+end
+
+action :stop do
+  if current_resource.started # ~FC023
+    converge_by ["stop volume #{volume_name}"] do
+      shell_out!('gluster', 'volume', 'stop', volume_name, input: "y\n")
+    end
+  end
+end
+
+action :delete do
+  if current_resource # ~FC023
+    converge_by ["delete volume #{volume_name}"] do
+      shell_out!('gluster', 'volume', 'delete', volume_name, input: "y\n")
+    end
+  end
+end


### PR DESCRIPTION
**UPDATED**

It currently supports the `start`, `stop`, and `delete` actions. It is also useful for checking existence in `only_if` blocks.

A `create` action could be added later and the top-level volume methods in libraries/gluster.rb could probably be reimplemented here.