### PR TITLE
Fetch 3.9 and 3.10 RPMs from mirror.centos.org now they're available

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -47,7 +47,7 @@ when 'ubuntu'
 when 'redhat', 'centos'
   # CentOS 6 and 7 have Gluster in the Storage SIG instead of a gluster hosted repo
   if node['platform_version'].to_i > 5
-    if Chef::VersionConstraint.new('>= 3.9').include?(node['gluster']['version'])
+    if Chef::VersionConstraint.new('>= 3.11').include?(node['gluster']['version'])
       subdomain = 'buildlogs'
       gpg_url = nil
     else


### PR DESCRIPTION
I've given 3.10 a try and it's looking good. I've left the default version as 3.8 but you can change that if you want.