### PR TITLE
remove s in backupvolfile-server

### DIFF
--- a/providers/mount.rb
+++ b/providers/mount.rb
@@ -85,7 +85,7 @@ def mount_options_for_backup_server
   when String
     ',backupvolfile-server=' + new_resource.backup_server
   when Array
-    ',backupvolfile-servers=' + new_resource.backup_server.join(':')
+    ',backupvolfile-server=' + new_resource.backup_server.join(':')
   end
 end
 


### PR DESCRIPTION
Hi,

Problem :

mount -t glusterfs -o defaults,_netdev,backupvolfile-servers=[HOST2] [HOST1]:/[VOLUME] [MOUNT_POINT]

Invalid option: backupvolfile-servers

I thinks the problem du in gluster/providers/mount.rb:88

backupvolfile-servers instead of backupvolfile-server