### PR TITLE
Fix error when creating a replicated volume with two replicas

### DIFF
--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -118,6 +118,7 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
         Chef::Log.warn('You have specified replicated, so the attribute replica_count will be set to be the same number as the bricks you have')
         node.normal['gluster']['server']['volumes'][volume_name]['replica_count'] = brick_count
         options = "replica #{brick_count}"
+        force = true if brick_count == 2
       when 'distributed-replicated'
         # brick count has to be a multiple of replica count
         if (brick_count % volume_values['replica_count']).nonzero?


### PR DESCRIPTION
gluster CLI requires the user to acknowledge creating a replicated
volume with two replicas. The prompt does not appear if "force" is
appended to the command (see https://github.com/gluster/glusterfs/blob/d1f15cdeb609a1b720a04a502f7a63b2d3922f41/cli/src/cli-cmd-parser.c#L532).
Therefore, add "force" to the command when creating a replicated volume
with two replicas.