### PR TITLE
Adding dynamic version constrain

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,4 @@
 
 default['gluster']['version'] = '3.8'
 default['gluster']['repo'] = 'public'
+default['gluster']['version_constraint'] = '>= 3.8'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'shortdudey123@gmail.com'
 license          'Apache-2.0'
 description      'Installs and configures Gluster servers and clients'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '6.2.0'
+version          '6.2.1'
 depends          'compat_resource', '>= 12.14.6'
 depends          'lvm', '>= 1.5.1'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'shortdudey123@gmail.com'
 license          'Apache-2.0'
 description      'Installs and configures Gluster servers and clients'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '6.2.1'
+version          '6.2.0'
 depends          'compat_resource', '>= 12.14.6'
 depends          'lvm', '>= 1.5.1'
 

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -47,7 +47,7 @@ when 'ubuntu'
 when 'redhat', 'centos'
   # CentOS 6 and 7 have Gluster in the Storage SIG instead of a gluster hosted repo
   if node['platform_version'].to_i > 5
-    if Chef::VersionConstraint.new('>= 3.11').include?(node['gluster']['version'])
+    if Chef::VersionConstraint.new(node['gluster']['version_constraint']).include?(node['gluster']['version'])
       subdomain = 'buildlogs'
       gpg_url = nil
     else


### PR DESCRIPTION
As the versions lower than 3.10 are not available in the main mirror anymore, the current cookbook is not working for versions 3.8 and 3.9. I've created the constraint version as an attribute, which makes any future changes in the Centos repo do not affect the cookbook directly.